### PR TITLE
fix npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,5 @@
     "yargs": "^5.0.0"
   },
   "scripts": {
-    "postinstall": "export AP_CODE_HOME=`pwd` && export AP_GIT_HOME=`git rev-parse --git-dir` && ln -s -f $AP_CODE_HOME/hooks/pre-commit $AP_GIT_HOME/hooks/pre-commit && chmod +x $AP_GIT_HOME/hooks/pre-commit"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "node": ">=6.0"
   },
   "private": true,
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "dependencies": {
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-es2015-without-strict": "0.0.4",
@@ -56,6 +55,6 @@
     "yargs": "^5.0.0"
   },
   "scripts": {
-    "postinstall": "ln -s -f ../../hooks/pre-commit .git/hooks/pre-commit && chmod +x hooks/pre-commit"
+    "postinstall": "export AP_CODE_HOME=`pwd` && export AP_GIT_HOME=`git rev-parse --git-dir` && ln -s -f $AP_CODE_HOME/hooks/pre-commit $AP_GIT_HOME/hooks/pre-commit && chmod +x $AP_GIT_HOME/hooks/pre-commit"
   }
 }


### PR DESCRIPTION
this fixes https://github.com/unicef/etools-issues/issues/786

I think maybe has to do with some of the submodule changes I made to `etools-infra` affecting where the `.git` folder ends up, but this change should (I think) be future proof.

@vkurup @robertavram 