### PR TITLE
[ch27653]Styles clean up

### DIFF
--- a/src_ts/elements/common-elements/engagement-overview-components/engagement-info-details/engagement-info-details.ts
+++ b/src_ts/elements/common-elements/engagement-overview-components/engagement-info-details/engagement-info-details.ts
@@ -160,7 +160,7 @@ class EngagementInfoDetails extends DateMixin(CommonMethodsMixin(PolymerElement)
               class$="validate-field  [[_setRequired('po_item', basePermissionPath)]]"
               selected="{{data.po_item}}"
               label="[[getLabel('po_item', basePermissionPath)]]"
-              placeholder="[[getPlaceholderText('po_item', basePermissionPath)]]"
+              placeholder="&#8212;"
               options="[[_getPoItems(data.agreement)]]"
               option-label="number"
               option-value="id"

--- a/src_ts/elements/common-elements/engagement-overview-components/engagement-staff-members-tab/engagement-staff-members-tab.ts
+++ b/src_ts/elements/common-elements/engagement-overview-components/engagement-staff-members-tab/engagement-staff-members-tab.ts
@@ -118,7 +118,7 @@ class EngagementStaffMembersTab extends TableElementsMixin(CommonMethodsMixin(Po
           position: relative;
           width: 100%;
           line-height: 40px;
-          color: var(--module-primary);
+          color: var(--primary-color);
           font-weight: 600;
           box-sizing: border-box;
           margin: 10px 0 0 !important;

--- a/src_ts/elements/common-elements/file-attachments-tab/file-attachments-tab-styles.ts
+++ b/src_ts/elements/common-elements/file-attachments-tab/file-attachments-tab-styles.ts
@@ -23,7 +23,7 @@ export const fileAttachmentsTabStyles = html`
 
     paper-input-container {
       margin: 0 12px;
-      --paper-input-container-focus-color: var(--module-primary);
+      --paper-input-container-focus-color: var(--primary-color);
       --paper-input-container: {
         color: var(--gray-50) !important;
         font-size: 13px;

--- a/src_ts/elements/common-elements/list-tab-elements/list-element/list-element.ts
+++ b/src_ts/elements/common-elements/list-tab-elements/list-element/list-element.ts
@@ -81,7 +81,7 @@ class ListElement extends LocalizationMixin(PolymerElement) {
           text-align: center;
         }
         :host .partner-data a.col-data {
-          color: var(--module-primary);
+          color: var(--primary-color);
           font-weight: 500;
           cursor: pointer;
         }
@@ -94,7 +94,7 @@ class ListElement extends LocalizationMixin(PolymerElement) {
         :host .partner-data a.col-data iron-icon {
           display: none;
           width: 16px;
-          color: var(--module-primary);
+          color: var(--primary-color);
         }
         :host .partner-data a.col-data.with-icon iron-icon {
           display: inline-flex;

--- a/src_ts/elements/common-elements/list-tab-elements/list-pagination/list-pagination.ts
+++ b/src_ts/elements/common-elements/list-tab-elements/list-pagination/list-pagination.ts
@@ -70,7 +70,7 @@ class ListPagination extends PolymerElement {
           --paper-input-container-input-overflow: hidden;
           --paper-input-container-input-text-overflow: ellipsis;
           --paper-input-container-input-color: var(--gray-mid);
-          --paper-input-container-focus-color: var(--module-primary);
+          --paper-input-container-focus-color: var(--primary-color);
           --iron-icon-height: 18px;
           --paper-input-container-shared-input-style: {
             font-size: 12px;

--- a/src_ts/elements/common-elements/list-tab-elements/list-tab-main/list-tab-main-styles.ts
+++ b/src_ts/elements/common-elements/list-tab-elements/list-tab-main/list-tab-main-styles.ts
@@ -22,7 +22,7 @@ export const ListTabMainStyles = html`
     .data-table .data-card-heading.table-title {
       margin-left: 0;
       text-align: center;
-      background-color: var(--module-primary);
+      background-color: var(--primary-color);
       line-height: 48px;
       color: #fff;
       margin-bottom: 17px;

--- a/src_ts/elements/common-elements/list-tab-elements/list-tab-main/list-tab-main.ts
+++ b/src_ts/elements/common-elements/list-tab-elements/list-tab-main/list-tab-main.ts
@@ -40,7 +40,7 @@ class ListTabMain extends PolymerElement {
         :host .data-table .data-card-heading.table-title {
           margin-left: 0;
           text-align: center;
-          background-color: var(--module-primary);
+          background-color: var(--primary-color);
           line-height: 48px;
           color: #fff;
           margin-bottom: 17px;

--- a/src_ts/elements/common-elements/pages-header-element/pages-header-element-styles.ts
+++ b/src_ts/elements/common-elements/pages-header-element/pages-header-element-styles.ts
@@ -66,7 +66,7 @@ const pagesHeaderElementStyles = html`
     }
 
     .side-heading paper-button.add-btn {
-      background-color: var(--module-primary);
+      background-color: var(--primary-color);
       color: white;
       height: 36px;
       font-weight: 500;
@@ -80,7 +80,7 @@ const pagesHeaderElementStyles = html`
 
     .side-heading .add-btn {
       margin: 11px 4px 12px 18px;
-      background-color: var(--module-primary);
+      background-color: var(--primary-color);
     }
 
     .side-heading-button-holder {

--- a/src_ts/elements/common-elements/search-and-filter-element/search-and-filter-styles.ts
+++ b/src_ts/elements/common-elements/search-and-filter-element/search-and-filter-styles.ts
@@ -66,8 +66,8 @@ export const searchAndFilterStyles = html`
     }
 
     .second-header #add-filter-container paper-button {
-      --paper-button_-_color: var(--module-primary);
-      color: var(--module-primary);
+      --paper-button_-_color: var(--primary-color);
+      color: var(--primary-color);
       font-weight: bold;
     }
 

--- a/src_ts/elements/common-elements/status-tab-element/action-buttons-styles.ts
+++ b/src_ts/elements/common-elements/status-tab-element/action-buttons-styles.ts
@@ -15,7 +15,7 @@ export const ActionButtonsStyles = html`
       --paper-button_-_color: #fff;
       height: 34px;
       color: #fff;
-      background-color: var(--module-primary);
+      background-color: var(--primary-color);
       margin: 0;
       width: 100%;
     }

--- a/src_ts/elements/common-elements/status-tab-element/status-tab-element-styles.ts
+++ b/src_ts/elements/common-elements/status-tab-element/status-tab-element-styles.ts
@@ -23,7 +23,7 @@ export const StatusTabElementStyles = html` <style>
   .status-buttons paper-button {
     height: 35px;
     color: #ffffff;
-    background-color: var(--module-primary);
+    background-color: var(--primary-color);
   }
 
   .status-buttons paper-button.with-actions {
@@ -173,7 +173,7 @@ export const StatusTabElementStyles = html` <style>
     display: none !important;
   }
   .status-container.active.first .status-icon .icon-wrapper {
-    background-color: var(--module-primary);
+    background-color: var(--primary-color);
   }
   .status-container.active.first iron-icon {
     display: none !important;

--- a/src_ts/elements/pages/audits/report-page-components/key-internal-controls-weaknesses/key-internal-controls-weaknesses.ts
+++ b/src_ts/elements/pages/audits/report-page-components/key-internal-controls-weaknesses/key-internal-controls-weaknesses.ts
@@ -55,7 +55,7 @@ class KeyInternalControlsWeaknesses extends CommonMethodsMixin(PolymerElement) {
           position: relative;
           width: 100%;
           line-height: 40px;
-          color: var(--module-primary);
+          color: var(--primary-color);
           font-weight: 600;
           box-sizing: border-box;
           margin: 10px 0 0 !important;

--- a/src_ts/elements/pages/engagements/new-engagement-view/new-engagement-view.ts
+++ b/src_ts/elements/pages/engagements/new-engagement-view/new-engagement-view.ts
@@ -55,7 +55,7 @@ class NewEngagementView extends EngagementMixin(LastCreatedMixin(CommonMethodsMi
             color: var(--gray-light);
           }
 
-          --ecp-header-bg: var(--module-primary);
+          --ecp-header-bg: var(--primary-color);
         }
 
         .tab-selector {
@@ -76,7 +76,7 @@ class NewEngagementView extends EngagementMixin(LastCreatedMixin(CommonMethodsMi
         }
 
         .tab-selector paper-tabs {
-          color: var(--module-primary);
+          color: var(--primary-color);
           font-size: 14px;
           font-weight: bold;
           text-transform: uppercase;

--- a/src_ts/elements/pages/micro-assessments/questionnaire-components/risk-tab/risk-tab-styles.ts
+++ b/src_ts/elements/pages/micro-assessments/questionnaire-components/risk-tab/risk-tab-styles.ts
@@ -84,7 +84,7 @@ export const RiskTabStyles = html`
     }
     etools-content-panel::part(ecp-header) {
       height: 51px;
-      background-color: var(--module-primary);
+      background-color: var(--primary-color);
     }
     etools-content-panel::part(ecp-content) {
       padding: 0;

--- a/src_ts/elements/pages/micro-assessments/report-page-components/key-internal-controls-tab-styles.ts
+++ b/src_ts/elements/pages/micro-assessments/report-page-components/key-internal-controls-tab-styles.ts
@@ -19,7 +19,7 @@ export const KeyInternalControlsTabStyles = html`
       position: relative;
       width: 100%;
       line-height: 40px;
-      color: var(--module-primary);
+      color: var(--primary-color);
       font-weight: 600;
       box-sizing: border-box;
       margin: 10px 0 0 !important;

--- a/src_ts/elements/styles/app-theme.ts
+++ b/src_ts/elements/styles/app-theme.ts
@@ -7,6 +7,7 @@ documentContainer.innerHTML = `
     <style>
         html {
           --primary-color: #0099ff;
+          --secondary-text-color: rgba(0, 0, 0, 0.54);
           --primary-background-color: #ffffff;
           --secondary-background-color: #eeeeee;
           --ternary-background-color: var(--paper-indigo-800);

--- a/src_ts/elements/styles/etools-file-styles.ts
+++ b/src_ts/elements/styles/etools-file-styles.ts
@@ -121,7 +121,7 @@ export const etoolsFileStyles = html`
         padding: 0 19px 0 12px;
         height: 36px;
         color: #ffffff;
-        background-color: var(--module-primary);
+        background-color: var(--primary-color);
       };
       @apply --etools-file-upload-button;
     }
@@ -146,7 +146,7 @@ export const etoolsFileStyles = html`
         padding: 10px 8px;
         margin: 18px 0 0;
         width: 50%;
-        color: var(--module-primary) !important;
+        color: var(--primary-color) !important;
       };
     }
 

--- a/src_ts/elements/styles/main-page-styles.ts
+++ b/src_ts/elements/styles/main-page-styles.ts
@@ -12,7 +12,7 @@ export const mainPageStyles = html`
       --paper-tab-content-unselected: {
         color: var(--gray-light);
       }
-      --ecp-header-bg: var(--module-primary);
+      --ecp-header-bg: var(--primary-color);
     }
 
     .view-container {
@@ -41,7 +41,7 @@ export const mainPageStyles = html`
     }
 
     .tab-selector paper-tabs {
-      color: var(--module-primary);
+      color: var(--primary-color);
       font-size: 14px;
       font-weight: bold;
     }
@@ -81,7 +81,7 @@ export const mainPageStyles = html`
 
     etools-content-panel.cancellation-tab::part(ecp-header) {
       height: 51px;
-      background-color: var(--module-primary);
+      background-color: var(--primary-color);
       border-bottom: none;
     }
 

--- a/src_ts/elements/styles/module-styles.ts
+++ b/src_ts/elements/styles/module-styles.ts
@@ -18,9 +18,9 @@ export const moduleStyles = html`
 
       --gray-border: rgba(0, 0, 0, 0.15);
 
-      /*--module-primary: #00AEEF;*/
-      --module-primary: #0099ff;
-      /*--module-primary-dark: #4893ff;*/
+      /*--primary-color: #00AEEF;*/
+      /* --primary-color: #0099ff; */
+      /*--primary-color-dark: #4893ff;*/
 
       --module-sec-blue: #0061e9;
       --module-sec-green: #009a54;
@@ -54,12 +54,12 @@ export const moduleStyles = html`
 
     /* TABS */
     paper-tabs {
-      --paper-tabs-selection-bar-color: var(--module-primary);
+      --paper-tabs-selection-bar-color: var(--primary-color);
     }
 
     paper-tab {
       --paper-tab-content: {
-        color: var(--module-primary);
+        color: var(--primary-color);
         text-transform: none;
         font-size: 14px;
         font-weight: 500;
@@ -77,7 +77,7 @@ export const moduleStyles = html`
 
     /* PAPER-TOGGLE-BUTTON */
     paper-toggle-button {
-      --paper-toggle-button-checked-button-color: var(--module-primary);
+      --paper-toggle-button-checked-button-color: var(--primary-color);
       --paper-toggle-button-checked-bar-color: rgba(0, 174, 239, 0.5);
       --paper-toggle-button-unchecked-button-color: rgba(241, 241, 241, 1);
       --paper-toggle-button-unchecked-bar-color: rgba(31, 31, 31, 0.26);
@@ -86,7 +86,7 @@ export const moduleStyles = html`
     /* CHECKBOX */
     paper-checkbox {
       --paper-checkbox-unchecked-color: var(--gray-mid);
-      --paper-checkbox-checked-color: var(--module-primary);
+      --paper-checkbox-checked-color: var(--primary-color);
       --paper-checkbox-label: {
         color: var(--gray-dark);
         font-size: 16px;
@@ -96,7 +96,7 @@ export const moduleStyles = html`
 
     paper-radio-button {
       --paper-radio-button-unchecked-color: var(--gray-mid);
-      --paper-radio-button-checked-color: var(--module-primary);
+      --paper-radio-button-checked-color: var(--primary-color);
     }
 
     etools-dropdown,

--- a/src_ts/elements/styles/tab-inputs-styles.ts
+++ b/src_ts/elements/styles/tab-inputs-styles.ts
@@ -213,24 +213,6 @@ export const tabInputsStyles = html`
       }
     }
 
-    paper-input.bold {
-      --paper-input-container-input: {
-        font-weight: 500;
-      }
-
-      --paper-input-container-underline-focus: {
-        display: none !important;
-      }
-
-      --paper-input-container-underline-disabled: {
-        display: none !important;
-      }
-
-      --paper-input-container-underline: {
-        display: none !important;
-      }
-    }
-
     paper-input.deleted {
       --paper-input-container-input: {
         color: #b0b0b0;
@@ -448,9 +430,6 @@ export const tabInputsStyles = html`
         display: none !important;
       }
       --paper-input-container-underline-focus: {
-        display: none;
-      }
-      --paper-input-container-underline-disabled: {
         display: none;
       }
     }

--- a/src_ts/elements/styles/tab-inputs-styles.ts
+++ b/src_ts/elements/styles/tab-inputs-styles.ts
@@ -103,11 +103,7 @@ export const tabInputsStyles = html`
       padding: 0 12px;
       outline: none !important;
 
-      --paper-input-container-color: var(--gray-dark, rgba(0, 0, 0, 0.87));
       --paper-input-container-input-color: var(--gray-dark, rgba(0, 0, 0, 0.87));
-      --esmm-placeholder-color: var(--gray-dark, rgba(0, 0, 0, 0.87));
-      --esmm-multi-placeholder-color: var(--gray-dark, rgba(0, 0, 0, 0.87));
-      --paper-input-container-focus-color: var(--primary-color, #0099ff);
 
       --paper-input-container-underline: {
         border-bottom: 1px solid var(--gray-mid, rgba(0, 0, 0, 0.54));
@@ -161,27 +157,16 @@ export const tabInputsStyles = html`
         display: block !important;
       }
 
-      --iron-autogrow-textarea-placeholder: {
-        color: var(--gray-20) !important;
-      }
       --iron-autogrow-textarea: {
         overflow: hidden;
         padding: 0;
       }
     }
 
-    etools-dropdown.no-data-fetched,
-    paper-input.no-data-fetched {
-      --esmm-placeholder-color: var(--gray-dark);
-      --paper-input-container-color: var(--gray-dark);
-    }
-
     etools-currency-amount-input {
       --etools-currency-container-label: {
         color: var(--gray-50);
       }
-      --paper-input-container-color: var(--gray-dark);
-      --paper-input-container-focus-color: var(--module-primary);
     }
 
     :host > * {
@@ -244,7 +229,7 @@ export const tabInputsStyles = html`
     .repeatable-item-container .form-title {
       position: relative;
       line-height: 40px;
-      color: var(--module-primary);
+      color: var(--primary-color);
       font-weight: 600;
       box-sizing: border-box;
       margin: 0 12px 15px !important;
@@ -310,7 +295,7 @@ export const tabInputsStyles = html`
     }
 
     .repeatable-item-actions .actions .action.add {
-      color: var(--module-primary);
+      color: var(--primary-color);
     }
 
     .repeatable-item-actions .actions .action[disabled] {
@@ -391,10 +376,6 @@ export const tabInputsStyles = html`
     paper-dropdown-menu[disabled],
     paper-input[disabled],
     datepicker-lite[disabled] {
-      --paper-input-container-focus-color: var(
-        --paper-input-container-label_-_color,
-        var(--paper-input-container-color, var(--secondary-text-color))
-      );
       --paper-input-container: {
         opacity: 1 !important;
       }
@@ -418,10 +399,6 @@ export const tabInputsStyles = html`
     paper-dropdown-menu[readonly],
     paper-input[readonly],
     datepicker-lite[readonly] {
-      --paper-input-container-focus-color: var(
-        --paper-input-container-label_-_color,
-        var(--paper-input-container-color, var(--secondary-text-color))
-      );
       --paper-input-container: {
         opacity: 1 !important;
       }


### PR DESCRIPTION
- Rely more on default values of the paper Css variables , like --secondary-text-color, --primary-color
- Remove redundant styles and CSS props
- Placeholder color is dictated by --paper-input-container-color, and it should be a lighter shade of gray that the actual text filled in
- [ch27653]